### PR TITLE
Refactor layer storage + make layer external

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.2.0",
-    "@earthstar-project/rich-threads-layer": "^0.1.1",
+    "@earthstar-project/rich-threads-layer": "^1.2.0",
     "@reach/combobox": "^0.16.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.2.0",
+    "@earthstar-project/rich-threads-layer": "^0.1.1",
     "@reach/combobox": "^0.16.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -6,7 +6,7 @@ import {
   WorkspaceLabel,
 } from "react-earthstar";
 import { Link, Outlet, useMatch } from "react-router-dom";
-import LetterboxLayer from "./letterbox-layer";
+import LetterboxLayer from "@earthstar-project/rich-threads-layer";
 import { PathWorkspaceLookupContext } from "./WorkspaceLookup";
 
 function WorkspaceSection({ workspace }: { workspace: string }) {

--- a/src/NewThreadForm.tsx
+++ b/src/NewThreadForm.tsx
@@ -49,8 +49,6 @@ export default function NewThreadForm() {
       return;
     }
 
-    console.log();
-
     setTitle(defaults?.title);
     setPostVal(defaults?.content);
   }, [currentDraftId, defaults?.title, defaults?.content]);
@@ -66,14 +64,12 @@ export default function NewThreadForm() {
       return;
     }
 
-    console.log({ content });
-
     const newDraftId = letterboxLayer.setThreadRootDraft(
       content,
       currentDraftId,
     );
 
-    if (!isErr(newDraftId)) {
+    if (!isErr(newDraftId)) {      
       setCurrentDraftId(newDraftId);
       setDidSaveDraft(true);
     }
@@ -107,8 +103,12 @@ export default function NewThreadForm() {
         if (currentDraftId) {
           letterboxLayer.clearThreadRootDraft(currentDraftId);
         }
+        
+        const author = res.root.doc.author;
+        const timestamp = letterboxLayer.getThreadRootTimestamp(res.root.doc);
+        const id = `${author}/${timestamp}`;
 
-        navigate(`/${workspaceLookup}/thread/${res.id}`);
+        navigate(`/${workspaceLookup}/thread/${id}`);
       }}
     >
       <input

--- a/src/NewThreadForm.tsx
+++ b/src/NewThreadForm.tsx
@@ -3,9 +3,9 @@ import * as React from "react";
 import { useCurrentAuthor } from "react-earthstar";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useDebounce, useDebouncedCallback } from "use-debounce";
-import { useLetterboxLayer } from "./letterbox-layer";
 import MarkdownPreview from "./MarkdownPreview";
 import { renderMarkdownPreview } from "./util/markdown";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
 
 function NewThreadBar() {
   const { workspaceLookup } = useParams();

--- a/src/ThreadListing.tsx
+++ b/src/ThreadListing.tsx
@@ -68,7 +68,7 @@ export default function ThreadListing() {
         </div>
         : <ol>
           {threadsToUse.map((thread) => {
-            return <React.Fragment key={thread.root.id}>
+            return <React.Fragment key={thread.root.doc.path}>
               <li>
                 <ThreadItem thread={thread} />
               </li>

--- a/src/ThreadListing.tsx
+++ b/src/ThreadListing.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { useCurrentAuthor, WorkspaceLabel } from "react-earthstar";
 import { Link, Outlet, useMatch } from "react-router-dom";
-import { useLetterboxLayer } from "./letterbox-layer";
 import ThreadItem from "./ThreadRootItem";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
 import { useWorkspaceAddrFromRouter } from "./WorkspaceLookup";
 
 function SpaceBar(

--- a/src/ThreadReplyForm.tsx
+++ b/src/ThreadReplyForm.tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 import { useCurrentAuthor } from "react-earthstar";
 import { useNavigate, useParams } from "react-router-dom";
 import { useDebouncedCallback } from "use-debounce";
-import { useLetterboxLayer } from "./letterbox-layer";
 import MarkdownPreview from "./MarkdownPreview";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
 
 export default function ThreadReplyForm() {
   const { authorPubKey, timestamp } = useParams();

--- a/src/ThreadReplyForm.tsx
+++ b/src/ThreadReplyForm.tsx
@@ -8,12 +8,13 @@ import { useLetterboxLayer } from "./util/use-letterbox-layer";
 
 export default function ThreadReplyForm() {
   const { authorPubKey, timestamp } = useParams();
-  const threadId = `${authorPubKey}/${timestamp}`;
+  
+  const timestampInt = parseInt(timestamp)
 
   const [currentAuthor] = useCurrentAuthor();
   const letterboxLayer = useLetterboxLayer();
   const [replyText, setReplyText] = React.useState(
-    letterboxLayer.getReplyDraft(threadId) || "",
+    letterboxLayer.getReplyDraft(timestampInt, authorPubKey) || "",
   );
   const navigate = useNavigate();
   const [didSaveDraft, setDidSaveDraft] = React.useState(false);
@@ -26,7 +27,7 @@ export default function ThreadReplyForm() {
   }, []);
 
   const writeDraft = useDebouncedCallback((content) => {
-    letterboxLayer.setReplyDraft(threadId, content);
+    letterboxLayer.setReplyDraft(timestampInt, authorPubKey, content);
 
     setDidSaveDraft(true);
   }, 1000);
@@ -38,14 +39,15 @@ export default function ThreadReplyForm() {
       e.preventDefault();
 
       const result = letterboxLayer.createReply(
-        threadId,
+        timestampInt,
+        authorPubKey,
         replyText,
       );
 
       if (isErr(result)) {
         alert("Something went wrong with creating this reply.");
       } else {
-        letterboxLayer.clearReplyDraft(threadId);
+        letterboxLayer.clearReplyDraft(timestampInt, authorPubKey);
       }
 
       navigate("..");

--- a/src/ThreadRootItem.tsx
+++ b/src/ThreadRootItem.tsx
@@ -1,9 +1,10 @@
+import { Thread } from "@earthstar-project/rich-threads-layer";
 import * as React from "react";
-import { Thread, ThreadRoot, useLetterboxLayer } from "./letterbox-layer";
 import { AuthorLabel } from "react-earthstar";
 import { Link, useMatch } from "react-router-dom";
 import ThreadTitle from "./ThreadTitle";
 import { renderMarkdownPreview } from "./util/markdown";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
 import { PathWorkspaceLookupContext } from "./WorkspaceLookup";
 
 export default function ThreadItem({ thread }: { thread: Thread }) {

--- a/src/ThreadRootItem.tsx
+++ b/src/ThreadRootItem.tsx
@@ -5,6 +5,7 @@ import { Link, useMatch } from "react-router-dom";
 import ThreadTitle from "./ThreadTitle";
 import { renderMarkdownPreview } from "./util/markdown";
 import { useLetterboxLayer } from "./util/use-letterbox-layer";
+import useThreadId from "./util/use-thread-id";
 import { PathWorkspaceLookupContext } from "./WorkspaceLookup";
 
 export default function ThreadItem({ thread }: { thread: Thread }) {
@@ -16,7 +17,9 @@ export default function ThreadItem({ thread }: { thread: Thread }) {
   const match = useMatch("/:workspace/thread/:pubKey/:timestamp/*");
 
   const isActive =
-    thread.root.id === `${match?.params.pubKey}/${match?.params.timestamp}`;
+    thread.root.doc.author === match?.params.pubKey && letterboxLayer.getThreadRootTimestamp(thread.root.doc) === parseInt(match?.params.timestamp);
+    
+  const id = useThreadId(thread)
 
   const markdownMemo = React.useMemo(
     () => renderMarkdownPreview(lastThreadItem.doc.content),
@@ -36,7 +39,7 @@ export default function ThreadItem({ thread }: { thread: Thread }) {
       className={"flex items-center gap-2"}
       to={`/${
         lookup.addrsToPaths[thread.root.doc.workspace]
-      }/thread/${thread.root.id}`}
+      }/thread/${id}`}
     >
       <div
         className={hasUnreadPosts

--- a/src/ThreadTitle.tsx
+++ b/src/ThreadTitle.tsx
@@ -1,4 +1,6 @@
-import { Thread, useLetterboxLayer } from "./letterbox-layer";
+import { Thread } from "@earthstar-project/rich-threads-layer";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
+
 
 export default function ThreadTitle(
   { thread, workspace }: { thread: Thread; workspace?: string },

--- a/src/ThreadView.tsx
+++ b/src/ThreadView.tsx
@@ -2,18 +2,18 @@ import * as React from "react";
 import { Document, isErr } from "earthstar";
 import { Link, Outlet, useMatch, useParams } from "react-router-dom";
 import LetterboxLayer, {
-  getDocPublishedTimestamp,
+
   Post,
   Thread,
   ThreadRoot,
-  useLetterboxLayer,
-} from "./letterbox-layer";
+} from "@earthstar-project/rich-threads-layer";
 import { formatDistanceToNow } from "date-fns";
 import { AuthorLabel, useCurrentAuthor, useStorage } from "react-earthstar";
 import { renderMarkdown } from "./util/markdown";
 import ThreadTitle from "./ThreadTitle";
 import MarkdownPreview from "./MarkdownPreview";
 import { useWorkspaceAddrFromRouter } from "./WorkspaceLookup";
+import { useLetterboxLayer } from "./util/use-letterbox-layer";
 
 function ThreadBar({ thread }: { thread: Thread }) {
   const match = useMatch("/:lookup/*");
@@ -24,7 +24,7 @@ function ThreadBar({ thread }: { thread: Thread }) {
 
   const lastThreadItem = letterboxLayer.lastThreadItem(thread);
 
-  const lastItemTimestamp = getDocPublishedTimestamp(lastThreadItem.doc);
+  const lastItemTimestamp = letterboxLayer.getDocPublishedTimestamp(lastThreadItem.doc);
 
   const mostRecentIsUnread = lastThreadItem
     ? letterboxLayer.isUnread(
@@ -76,7 +76,7 @@ function PostDetails(
 
   const letterboxLayer = new LetterboxLayer(storage, currentAuthor);
 
-  const firstPostedTimestamp = getDocPublishedTimestamp(post.doc);
+  const firstPostedTimestamp = letterboxLayer.getDocPublishedTimestamp(post.doc);
   const isUnread = letterboxLayer.isUnread(threadId, firstPostedTimestamp);
 
   const isOwnPost = currentAuthor?.address === post.doc.author;
@@ -153,7 +153,7 @@ function PostEditForm(
 
   const letterboxLayer = useLetterboxLayer();
 
-  const publishedTimestamp = getDocPublishedTimestamp(doc);
+  const publishedTimestamp = letterboxLayer.getDocPublishedTimestamp(doc);
 
   return <form
     className="flex flex-col mt-3"
@@ -183,9 +183,9 @@ function PostEditForm(
 }
 
 function ThreadRootView({ root }: { root: ThreadRoot }) {
-  const letterBoxLayer = useLetterboxLayer();
-  const firstPostedTimestamp = getDocPublishedTimestamp(root.doc);
-  const isUnread = letterBoxLayer.isUnread(root.id, firstPostedTimestamp);
+  const letterboxLayer = useLetterboxLayer();
+  const firstPostedTimestamp = letterboxLayer.getDocPublishedTimestamp(root.doc);
+  const isUnread = letterboxLayer.isUnread(root.id, firstPostedTimestamp);
 
   const [isEditing, setIsEditing] = React.useState(false);
 
@@ -207,7 +207,7 @@ function ThreadRootView({ root }: { root: ThreadRoot }) {
         );
 
         if (shouldDelete) {
-          letterBoxLayer.editPost(firstPostedTimestamp, "");
+          letterboxLayer.editPost(firstPostedTimestamp, "");
         }
       }}
     />
@@ -218,9 +218,9 @@ function ThreadRootView({ root }: { root: ThreadRoot }) {
 }
 
 function PostView({ post, threadId }: { post: Post; threadId: string }) {
-  const letterBoxLayer = useLetterboxLayer();
-  const firstPostedTimestamp = getDocPublishedTimestamp(post.doc);
-  const isUnread = letterBoxLayer.isUnread(threadId, firstPostedTimestamp);
+  const letterboxLayer = useLetterboxLayer();
+  const firstPostedTimestamp = letterboxLayer.getDocPublishedTimestamp(post.doc);
+  const isUnread = letterboxLayer.isUnread(threadId, firstPostedTimestamp);
 
   const [isEditing, setIsEditing] = React.useState(false);
 
@@ -237,7 +237,7 @@ function PostView({ post, threadId }: { post: Post; threadId: string }) {
       post={post}
       threadId={threadId}
       onDelete={() => {
-        letterBoxLayer.editPost(firstPostedTimestamp, "");
+        letterboxLayer.editPost(firstPostedTimestamp, "");
       }}
     />
     {isEditing

--- a/src/util/is-root-post.ts
+++ b/src/util/is-root-post.ts
@@ -1,0 +1,5 @@
+import { Document } from 'earthstar'
+
+export default function isRootPost(doc: Document) {
+  return doc.path.startsWith(`/letterbox/rootthread`);
+}

--- a/src/util/use-letterbox-layer.ts
+++ b/src/util/use-letterbox-layer.ts
@@ -1,0 +1,15 @@
+import { useCurrentAuthor, useStorage } from "react-earthstar";
+import { useWorkspaceAddrFromRouter } from "../WorkspaceLookup";
+
+import LetterboxLayer from '@earthstar-project/rich-threads-layer'
+
+export function useLetterboxLayer(workspaceAddress?: string) {
+  const inferredWorkspace = useWorkspaceAddrFromRouter();
+
+  const storage = useStorage(workspaceAddress || inferredWorkspace);
+  const [currentAuthor] = useCurrentAuthor();
+
+  const layer = new LetterboxLayer(storage, currentAuthor);
+
+  return layer;
+}

--- a/src/util/use-thread-id.ts
+++ b/src/util/use-thread-id.ts
@@ -1,0 +1,9 @@
+import { Thread } from "@earthstar-project/rich-threads-layer";
+import { useLetterboxLayer } from "./use-letterbox-layer";
+
+export default function useThreadId(thread: Thread) {
+  const layer = useLetterboxLayer();
+  const author = thread.root.doc.author;
+  const timestamp = layer.getThreadRootTimestamp(thread.root.doc);
+  return `${author}/${timestamp}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,6 +1480,14 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@earthstar-project/rich-threads-layer@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@earthstar-project/rich-threads-layer/-/rich-threads-layer-0.1.1.tgz#28bff77a58d16cc05621ce93851ce163be206967"
+  integrity sha512-8UtTJuQCxUnjiVv2TilJlZUzLKmnJbll+h7/LBD3l4OspX/bKJe4DQURCqobhkeAsvR+49AJrFAfcO9g5xETBA==
+  dependencies:
+    earthstar "^6.8.5"
+    earthstar-graph-db "^2.0.0"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,10 +1480,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@earthstar-project/rich-threads-layer@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@earthstar-project/rich-threads-layer/-/rich-threads-layer-0.1.1.tgz#28bff77a58d16cc05621ce93851ce163be206967"
-  integrity sha512-8UtTJuQCxUnjiVv2TilJlZUzLKmnJbll+h7/LBD3l4OspX/bKJe4DQURCqobhkeAsvR+49AJrFAfcO9g5xETBA==
+"@earthstar-project/rich-threads-layer@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@earthstar-project/rich-threads-layer/-/rich-threads-layer-1.2.0.tgz#50216d2a03560948e51a703592a260eabb369123"
+  integrity sha512-fcqMPADTVbMeWDz1YXgAZdwwZCwo8dBdyaySf6zbKzUfLybTIEFB8wbwQ05/MJDFmfdhR9HhizFPYg0yRnPqPw==
   dependencies:
     earthstar "^6.8.5"
     earthstar-graph-db "^2.0.0"


### PR DESCRIPTION
Two big things:

- Letterbox layer has been pulled out into a new 'rich threads' layer (with tests!)
- The rich threads layer now uses paths instead of earthstar-graph-db, making it much quicker